### PR TITLE
Fix documentation custom compliance sample

### DIFF
--- a/docs/user/app_feature_compliancecustom.md
+++ b/docs/user/app_feature_compliancecustom.md
@@ -104,7 +104,7 @@ import re
 BGP_PATTERN = re.compile("\s*neighbor (?P<ip>\d+\.\d+\.\d+\.\d+) .*")
 BGP_SECRET = re.compile("\s*neighbor (?P<ip>\d+\.\d+\.\d+\.\d+) password (\S+).*")
 def custom_compliance_func(obj):
-    if obj.rule == 'bgp' and obj.device.platform.network_driver == 'cisco_ios':
+    if obj.rule.feature.slug == 'bgp' and obj.device.platform.network_driver == 'cisco_ios':
         actual_config = obj.actual
         neighbors = []
         secrets = []


### PR DESCRIPTION
if expression of the example will never be true because obj.rule is of type ComplianceRule and its string representation is `f"{self.platform} - {self.feature.name}"`